### PR TITLE
Introduce GeniusLifeApp simulation, update UI, scripts and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>UHO: Fate of the Grid</title>
+  <title>NeoKylä Genius Life Simulator</title>
   <style>
     body {
       margin: 0;
@@ -104,6 +104,51 @@
     .message.drug {
       color: #ff66ff;
     }
+
+    #controlsPanel {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+
+    #controlsPanel button {
+      background: #151f38;
+      border: 1px solid #5566aa;
+      color: #e8eeff;
+      padding: 6px 8px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 12px;
+    }
+
+    #controlsPanel button:hover {
+      background: #213160;
+    }
+
+    .controls-hint {
+      color: #9fb0da;
+      font-size: 11px;
+      line-height: 1.3;
+      margin-top: 4px;
+    }
+
+    .control-label {
+      display: grid;
+      gap: 4px;
+      font-size: 11px;
+      color: #d2ddff;
+    }
+
+    .control-label input[type='range'] {
+      width: 100%;
+      accent-color: #6ca0ff;
+    }
+
+    .mode-row {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 6px;
+    }
   </style>
 </head>
 <body>
@@ -111,35 +156,27 @@
     <canvas id="gameCanvas" width="800" height="600"></canvas>
     <div id="ui">
       <div class="ui-panel">
-        <div class="ui-title">Tilastot</div>
+        <div class="ui-title">NeoKylä Data</div>
         <div id="statsPanel"></div>
       </div>
       
       <div class="ui-panel">
-        <div class="ui-title">Tarpeet</div>
+        <div class="ui-title">Elämän voimat</div>
         <div id="needsPanel"></div>
       </div>
       
       <div class="ui-panel">
-        <div class="ui-title">Tila</div>
-        <div id="statusPanel">
-          <div class="stat-row">
-            <span>Käteinen:</span>
-            <span id="cash">0€</span>
-          </div>
-          <div class="stat-row">
-            <span>Pankki:</span>
-            <span id="bank">0€</span>
-          </div>
-          <div class="stat-row">
-            <span>Kuumuus:</span>
-            <span id="heat">0</span>
-          </div>
-        </div>
+        <div class="ui-title">Simulaation tila</div>
+        <div id="statusPanel"></div>
+      </div>
+
+      <div class="ui-panel">
+        <div class="ui-title">Ohjaimet</div>
+        <div id="controlsPanel"></div>
       </div>
       
       <div class="ui-panel">
-        <div class="ui-title">Viestit</div>
+        <div class="ui-title">Tapahtumaloki</div>
         <div id="messageLog"></div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,56 @@
         "@types/howler": "^2.2.12",
         "@types/node": "^20.0.0",
         "@vitest/ui": "^1.0.0",
+        "jsdom": "^28.1.0",
         "typescript": "^5.0.0",
         "vite": "^5.0.0",
         "vitest": "^1.0.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
@@ -30,6 +76,151 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
+      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -421,6 +612,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/schemas": {
@@ -1360,6 +1569,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1599,6 +1818,16 @@
       "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/big.js": {
@@ -1854,6 +2083,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1871,6 +2144,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -2009,6 +2289,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2543,6 +2836,47 @@
       "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2776,6 +3110,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -2930,6 +3271,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3021,6 +3403,16 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -3039,6 +3431,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -3309,6 +3708,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3529,7 +3941,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3654,6 +4065,19 @@
       "resolved": "https://registry.npmjs.org/sample-rate/-/sample-rate-2.0.1.tgz",
       "integrity": "sha512-AIK0vVBiAEObmpJOxQu/WCyklnWGqzTSDII4O7nBo+SJHmfgBUiYhgV/Y3Ohz76gfSlU6R5CIAKggj+nAOLSvg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -3981,6 +4405,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
@@ -4133,6 +4564,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.24",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.24.tgz",
+      "integrity": "sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.24"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.24",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
+      "integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4172,6 +4623,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4208,6 +4685,16 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -4404,6 +4891,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -4416,6 +4916,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webmidi": {
@@ -4543,6 +5053,31 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4633,6 +5168,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "dev:sim": "node node_modules/vite/bin/vite.js --host 0.0.0.0 --port 4173 --strictPort",
+    "typecheck:sim": "node node_modules/typescript/bin/tsc --noEmit --target ES2022 --lib ES2022,DOM --moduleResolution bundler --allowImportingTsExtensions --skipLibCheck src/genius-life-app.ts src/main.ts",
+    "build:sim": "node node_modules/vite/bin/vite.js build",
+    "test:fast": "node node_modules/vitest/vitest.mjs run --passWithNoTests"
   },
   "keywords": [
     "game",
@@ -24,6 +28,7 @@
     "@types/howler": "^2.2.12",
     "@types/node": "^20.0.0",
     "@vitest/ui": "^1.0.0",
+    "jsdom": "^28.1.0",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vitest": "^1.0.0"

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -1,0 +1,740 @@
+type NeedName = 'energy' | 'social' | 'curiosity' | 'health';
+type Profession = 'Keksijä' | 'Taiteilija' | 'Opettaja' | 'Rakentaja';
+
+export interface NeedsState {
+  energy: number;
+  social: number;
+  curiosity: number;
+  health: number;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function squaredDistance(ax: number, ay: number, bx: number, by: number): number {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}
+
+export function computeMood(needs: NeedsState, profession: Profession): number {
+  const base = (needs.energy + needs.social + needs.curiosity + needs.health) / 4;
+  const professionBonus = profession === 'Taiteilija' ? 2 : profession === 'Opettaja' ? 1.5 : 1;
+  return clamp(base + professionBonus, 0, 100);
+}
+
+export function createSeededRandom(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (1664525 * s + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+interface Citizen {
+  id: number;
+  name: string;
+  profession: Profession;
+  age: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  mood: number;
+  needs: NeedsState;
+  creativity: number;
+  connections: number[];
+  alive: boolean;
+}
+
+interface GlobalState {
+  season: 'kevät' | 'kesä' | 'syksy' | 'talvi';
+  innovationPoints: number;
+  speed: 1 | 2 | 4;
+  paused: boolean;
+  harmonyBoost: number;
+  debugOverlay: boolean;
+  visualFx: boolean;
+  simIntensity: number;
+  mode: 'Calm' | 'Balanced' | 'Chaos';
+}
+
+type SimMode = GlobalState['mode'];
+
+export function inferModeForIntensity(intensity: number): SimMode {
+  if (intensity <= 0.8) return 'Calm';
+  if (intensity >= 1.6) return 'Chaos';
+  return 'Balanced';
+}
+
+const NAMES = ['Aino', 'Eero', 'Veera', 'Sisu', 'Lumi', 'Milo', 'Nora', 'Onni', 'Helmi', 'Otso'];
+const PROFESSIONS: Profession[] = ['Keksijä', 'Taiteilija', 'Opettaja', 'Rakentaja'];
+const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
+
+export class GeniusLifeApp {
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D;
+  private citizens: Citizen[] = [];
+  private nextId = 1;
+  private year = 2040;
+  private tick = 0;
+  private raf = 0;
+  private lastTime = 0;
+
+  private messageLog: HTMLElement;
+  private statsPanel: HTMLElement;
+  private needsPanel: HTMLElement;
+  private statusPanel: HTMLElement;
+  private controlsPanel: HTMLElement;
+  private pauseBtn: HTMLButtonElement | null = null;
+  private speedBtn: HTMLButtonElement | null = null;
+  private overlayBtn: HTMLButtonElement | null = null;
+  private keydownHandler: ((event: KeyboardEvent) => void) | null = null;
+  private resizeHandler: (() => void) | null = null;
+  private visibilityHandler: (() => void) | null = null;
+  private fps = 0;
+  private frameCounter = 0;
+  private frameTimer = 0;
+  private previousPopulation = 0;
+  private running = false;
+  private backgroundDrift = 0;
+  private readonly uiUpdateStride = 4;
+  private random = Math.random;
+  private activeSeed: number | null = null;
+
+  private state: GlobalState = {
+    season: 'kevät',
+    innovationPoints: 0,
+    speed: 1,
+    paused: false,
+    harmonyBoost: 0,
+    debugOverlay: true,
+    visualFx: true,
+    simIntensity: 1,
+    mode: 'Balanced'
+  };
+
+  constructor() {
+    const canvas = document.getElementById('gameCanvas') as HTMLCanvasElement | null;
+    const messageLog = document.getElementById('messageLog');
+    const statsPanel = document.getElementById('statsPanel');
+    const needsPanel = document.getElementById('needsPanel');
+    const statusPanel = document.getElementById('statusPanel');
+    const controlsPanel = document.getElementById('controlsPanel');
+
+    if (!canvas || !messageLog || !statsPanel || !needsPanel || !statusPanel || !controlsPanel) {
+      throw new Error('GeniusLifeApp: required DOM elements are missing.');
+    }
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('GeniusLifeApp: 2D canvas context could not be created.');
+    }
+
+    this.canvas = canvas;
+    this.ctx = context;
+    this.messageLog = messageLog;
+    this.statsPanel = statsPanel;
+    this.needsPanel = needsPanel;
+    this.statusPanel = statusPanel;
+    this.controlsPanel = controlsPanel;
+
+    this.bootstrapRandomSource();
+
+    this.seedWorld();
+    this.setupControls();
+    this.setupResizeHandler();
+    this.log('🌱 NeoKylä syntyi: elämä alkaa ikkuna-universumissa.', 'system');
+    this.log('🧪 Vinkki: käytä ohjaimia ja laita turbo päälle.', 'system');
+    this.updatePanels();
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.lastTime = performance.now();
+    this.loop(this.lastTime);
+  }
+
+  stop(): void {
+    this.running = false;
+    cancelAnimationFrame(this.raf);
+
+    if (this.keydownHandler) {
+      window.removeEventListener('keydown', this.keydownHandler);
+    }
+
+    if (this.resizeHandler) {
+      window.removeEventListener('resize', this.resizeHandler);
+    }
+
+    if (this.visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.visibilityHandler);
+    }
+  }
+
+  private setupResizeHandler(): void {
+    this.resizeHandler = () => {
+      const rect = this.canvas.getBoundingClientRect();
+      const nextWidth = Math.max(640, Math.floor(rect.width));
+      const nextHeight = Math.max(420, Math.floor(rect.height));
+
+      if (nextWidth !== this.canvas.width || nextHeight !== this.canvas.height) {
+        this.canvas.width = nextWidth;
+        this.canvas.height = nextHeight;
+      }
+    };
+
+    this.resizeHandler();
+    window.addEventListener('resize', this.resizeHandler);
+  }
+
+  private setupControls(): void {
+    this.controlsPanel.innerHTML = `
+      <button id="pauseBtn">⏸️ Pause</button>
+      <button id="speedBtn">⚡ Nopeus x1</button>
+      <button id="boostBtn">✨ Harmonia-buusti</button>
+      <button id="ideaBtn">🧠 Ideapurkaus</button>
+      <button id="overlayBtn">📊 Overlay: ON</button>
+      <button id="fxBtn">✨ Efektit: ON</button>
+      <button id="seedBtn">🎲 Satunnainen seed</button>
+      <div class="mode-row">
+        <button id="modeCalmBtn">🟢 Calm</button>
+        <button id="modeBalancedBtn">🟡 Balanced</button>
+        <button id="modeChaosBtn">🔴 Chaos</button>
+      </div>
+      <label class="control-label">Simulaation intensiteetti
+        <input id="intensityInput" type="range" min="0.5" max="2" step="0.1" value="1" />
+      </label>
+      <button id="resetBtn">🔄 Uusi maailma</button>
+      <div class="controls-hint">Pikanäppäimet: [Space] pause, [F] speed, [D] overlay, [R] reset</div>
+    `;
+
+    this.pauseBtn = document.getElementById('pauseBtn') as HTMLButtonElement | null;
+    this.speedBtn = document.getElementById('speedBtn') as HTMLButtonElement | null;
+    this.overlayBtn = document.getElementById('overlayBtn') as HTMLButtonElement | null;
+    const boostBtn = document.getElementById('boostBtn') as HTMLButtonElement;
+    const ideaBtn = document.getElementById('ideaBtn') as HTMLButtonElement;
+    const fxBtn = document.getElementById('fxBtn') as HTMLButtonElement;
+    const seedBtn = document.getElementById('seedBtn') as HTMLButtonElement;
+    const modeCalmBtn = document.getElementById('modeCalmBtn') as HTMLButtonElement;
+    const modeBalancedBtn = document.getElementById('modeBalancedBtn') as HTMLButtonElement;
+    const modeChaosBtn = document.getElementById('modeChaosBtn') as HTMLButtonElement;
+    const intensityInput = document.getElementById('intensityInput') as HTMLInputElement;
+    const resetBtn = document.getElementById('resetBtn') as HTMLButtonElement;
+
+    const togglePause = () => {
+      this.state.paused = !this.state.paused;
+      if (this.pauseBtn) this.pauseBtn.textContent = this.state.paused ? '▶️ Jatka' : '⏸️ Pause';
+      this.log(this.state.paused ? '⏸️ Simulaatio pysäytetty hetkeksi.' : '▶️ Simulaatio jatkuu.', 'system');
+    };
+
+    const switchSpeed = () => {
+      this.state.speed = this.state.speed === 1 ? 2 : this.state.speed === 2 ? 4 : 1;
+      if (this.speedBtn) this.speedBtn.textContent = `⚡ Nopeus x${this.state.speed}`;
+      this.log(`⚙️ Simulaation nopeus vaihdettu tasolle x${this.state.speed}.`, 'system');
+    };
+
+    this.pauseBtn?.addEventListener('click', togglePause);
+    this.speedBtn?.addEventListener('click', switchSpeed);
+    boostBtn.addEventListener('click', () => this.activateHarmonyBoost());
+    ideaBtn.addEventListener('click', () => this.triggerIdeaBurst());
+    this.overlayBtn?.addEventListener('click', () => {
+      this.state.debugOverlay = !this.state.debugOverlay;
+      if (this.overlayBtn) this.overlayBtn.textContent = `📊 Overlay: ${this.state.debugOverlay ? 'ON' : 'OFF'}`;
+    });
+    fxBtn.addEventListener('click', () => {
+      this.state.visualFx = !this.state.visualFx;
+      fxBtn.textContent = `✨ Efektit: ${this.state.visualFx ? 'ON' : 'OFF'}`;
+    });
+    seedBtn.addEventListener('click', () => {
+      this.activeSeed = Math.floor(Math.random() * 0xffffffff);
+      this.random = createSeededRandom(this.activeSeed);
+      this.resetWorld();
+      this.log(`🎲 Uusi seed käytössä: ${this.activeSeed}`, 'system');
+    });
+    intensityInput.addEventListener('input', () => {
+      this.state.simIntensity = Number(intensityInput.value);
+      this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+    });
+
+    modeCalmBtn.addEventListener('click', () => {
+      this.applyMode('Calm', intensityInput);
+      this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+    });
+    modeBalancedBtn.addEventListener('click', () => {
+      this.applyMode('Balanced', intensityInput);
+      this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+    });
+    modeChaosBtn.addEventListener('click', () => {
+      this.applyMode('Chaos', intensityInput);
+      this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+    });
+
+    this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+    resetBtn.addEventListener('click', () => this.resetWorld());
+
+    this.keydownHandler = (event) => {
+      if (event.repeat) return;
+
+      if (event.code === 'Space') {
+        event.preventDefault();
+        togglePause();
+      } else if (event.key.toLowerCase() === 'f') {
+        switchSpeed();
+      } else if (event.key.toLowerCase() === 'd') {
+        this.state.debugOverlay = !this.state.debugOverlay;
+        if (this.overlayBtn) this.overlayBtn.textContent = `📊 Overlay: ${this.state.debugOverlay ? 'ON' : 'OFF'}`;
+      } else if (event.key.toLowerCase() === 'r') {
+        this.resetWorld();
+      } else if (event.key === '1') {
+        this.applyMode('Calm', intensityInput);
+        this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+      } else if (event.key === '2') {
+        this.applyMode('Balanced', intensityInput);
+        this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+      } else if (event.key === '3') {
+        this.applyMode('Chaos', intensityInput);
+        this.updateModeButtons(modeCalmBtn, modeBalancedBtn, modeChaosBtn);
+      }
+    };
+
+    this.visibilityHandler = () => {
+      if (document.visibilityState === 'hidden' && !this.state.paused) {
+        this.state.paused = true;
+        if (this.pauseBtn) this.pauseBtn.textContent = '▶️ Jatka';
+      }
+    };
+
+    window.addEventListener('keydown', this.keydownHandler);
+    document.addEventListener('visibilitychange', this.visibilityHandler);
+  }
+
+  private resetWorld(): void {
+    this.citizens = [];
+    this.nextId = 1;
+    this.tick = 0;
+    this.year = 2040;
+    this.state.innovationPoints = 0;
+    this.state.harmonyBoost = 0;
+    this.state.debugOverlay = true;
+    this.state.visualFx = true;
+    this.state.simIntensity = 1;
+    this.state.mode = 'Balanced';
+    this.state.season = 'kevät';
+    this.state.paused = false;
+    this.state.speed = 1;
+    this.seedWorld();
+
+    if (this.pauseBtn) this.pauseBtn.textContent = '⏸️ Pause';
+    if (this.speedBtn) this.speedBtn.textContent = '⚡ Nopeus x1';
+    if (this.overlayBtn) this.overlayBtn.textContent = '📊 Overlay: ON';
+    const fxBtn = document.getElementById('fxBtn') as HTMLButtonElement | null;
+    const intensityInput = document.getElementById('intensityInput') as HTMLInputElement | null;
+    if (fxBtn) fxBtn.textContent = '✨ Efektit: ON';
+    if (intensityInput) intensityInput.value = '1';
+
+    this.updatePanels();
+    this.log('🌍 Uusi maailma luotu. NeoKylä alkaa alusta.', 'system');
+  }
+
+  private activateHarmonyBoost(): void {
+    if (this.state.innovationPoints < 40) {
+      this.log('❗ Harmonia-buusti vaatii 40 innovaatiopistettä.', 'system');
+      return;
+    }
+    this.state.innovationPoints = Math.max(0, this.state.innovationPoints - 40);
+    this.state.harmonyBoost = 900;
+    this.updatePanels();
+    this.log('✨ Harmonia-buusti aktivoitu! Kaikki saavat hyvinvointia.', 'system');
+  }
+
+  private triggerIdeaBurst(): void {
+    const best = [...this.citizens].sort((a, b) => b.creativity - a.creativity).slice(0, 3);
+    if (best.length === 0) return;
+
+    best.forEach((citizen) => {
+      citizen.needs.curiosity = Math.min(100, citizen.needs.curiosity + 35);
+      citizen.needs.energy = Math.max(10, citizen.needs.energy - 15);
+      citizen.creativity = Math.min(100, citizen.creativity + 8);
+    });
+
+    this.state.innovationPoints += 12;
+    this.updatePanels();
+    this.log('🧠 Ideapurkaus! Luovimmat asukkaat tekivät läpimurron.', 'system');
+  }
+
+  private applyMode(mode: SimMode, intensityInput: HTMLInputElement): void {
+    this.state.mode = mode;
+    const intensity = mode === 'Calm' ? 0.7 : mode === 'Balanced' ? 1 : 1.8;
+    this.state.simIntensity = intensity;
+    intensityInput.value = String(intensity);
+    this.log(`🧭 Simulaatiotila: ${mode}`, 'system');
+  }
+
+  private updateModeButtons(calm: HTMLButtonElement, balanced: HTMLButtonElement, chaos: HTMLButtonElement): void {
+    const guessedMode = inferModeForIntensity(this.state.simIntensity);
+    this.state.mode = guessedMode;
+
+    calm.style.outline = guessedMode === 'Calm' ? '2px solid #6fe3a2' : 'none';
+    balanced.style.outline = guessedMode === 'Balanced' ? '2px solid #f6e05e' : 'none';
+    chaos.style.outline = guessedMode === 'Chaos' ? '2px solid #ff7b7b' : 'none';
+  }
+
+  private seedWorld(): void {
+    for (let i = 0; i < 14; i++) {
+      this.citizens.push(this.createCitizen(this.random() * this.canvas.width, this.random() * this.canvas.height));
+    }
+  }
+
+  private createCitizen(x: number, y: number): Citizen {
+    const profession = PROFESSIONS[Math.floor(this.random() * PROFESSIONS.length)];
+    return {
+      id: this.nextId++,
+      name: `${NAMES[Math.floor(this.random() * NAMES.length)]}-${Math.floor(this.random() * 90 + 10)}`,
+      profession,
+      age: Math.floor(this.random() * 30) + 18,
+      x,
+      y,
+      vx: (this.random() - 0.5) * 0.8,
+      vy: (this.random() - 0.5) * 0.8,
+      mood: 70,
+      needs: {
+        energy: 65 + this.random() * 30,
+        social: 45 + this.random() * 45,
+        curiosity: 45 + this.random() * 45,
+        health: 60 + this.random() * 35
+      },
+      creativity: 40 + this.random() * 60,
+      connections: [],
+      alive: true
+    };
+  }
+
+  private loop = (now: number): void => {
+    if (!this.running) return;
+    const dt = Math.min((now - this.lastTime) / 1000, 0.05);
+    this.lastTime = now;
+    this.updateFps(dt);
+
+    if (!this.state.paused) {
+      this.update(dt * this.state.speed);
+    }
+    this.render();
+    this.raf = requestAnimationFrame(this.loop);
+  };
+
+  private update(dt: number): void {
+    this.tick += 1;
+
+    if (this.tick % 240 === 0) {
+      this.year += 1;
+      this.state.season = SEASONS[this.year % SEASONS.length];
+      this.log(`📅 Vuosi ${this.year}: ${this.state.season} muokkaa tunnelmaa.`);
+    }
+
+    this.previousPopulation = this.citizens.length;
+
+    if (this.state.harmonyBoost > 0) {
+      this.state.harmonyBoost -= 1;
+    }
+
+    for (const citizen of this.citizens) {
+      if (!citizen.alive) continue;
+
+      const seasonModifier = this.state.season === 'talvi' ? 1.15 : this.state.season === 'kesä' ? 0.88 : 1;
+      citizen.age += dt * 0.08;
+      const pace = this.state.simIntensity;
+      citizen.needs.energy -= dt * 3.1 * seasonModifier * pace;
+      citizen.needs.social -= dt * 1.1 * pace;
+      citizen.needs.curiosity -= dt * 1.3 * pace;
+      citizen.needs.health -= dt * 0.85 * seasonModifier * pace;
+
+      if (this.state.harmonyBoost > 0) {
+        citizen.needs.social += dt * 2.8;
+        citizen.needs.health += dt * 2.2;
+      }
+
+      citizen.mood = computeMood(citizen.needs, citizen.profession);
+
+      if (citizen.needs.energy < 25) {
+        citizen.vx *= 0.985;
+        citizen.vy *= 0.985;
+        citizen.needs.energy += dt * 2.9;
+      }
+
+      if (citizen.needs.curiosity < 45) {
+        citizen.creativity += dt * 1.8;
+        citizen.needs.curiosity += dt * 1.9;
+      }
+
+      if (citizen.needs.social < 35) {
+        const friend = this.findNearestCitizen(citizen);
+        if (friend) {
+          const dx = friend.x - citizen.x;
+          const dy = friend.y - citizen.y;
+          const len = Math.hypot(dx, dy) || 1;
+          citizen.vx += (dx / len) * dt * 0.38;
+          citizen.vy += (dy / len) * dt * 0.38;
+        }
+      }
+
+      citizen.x += citizen.vx * 60 * dt * pace;
+      citizen.y += citizen.vy * 60 * dt * pace;
+
+      if (citizen.x < 12 || citizen.x > this.canvas.width - 12) citizen.vx *= -1;
+      if (citizen.y < 12 || citizen.y > this.canvas.height - 12) citizen.vy *= -1;
+
+      citizen.x = Math.max(12, Math.min(this.canvas.width - 12, citizen.x));
+      citizen.y = Math.max(12, Math.min(this.canvas.height - 12, citizen.y));
+
+      for (const need of Object.keys(citizen.needs) as NeedName[]) {
+        citizen.needs[need] = clamp(citizen.needs[need], 0, 100);
+      }
+
+      citizen.creativity = clamp(citizen.creativity, 0, 100);
+
+      if (citizen.age > 95 || citizen.needs.health <= 0) {
+        citizen.alive = false;
+        this.log(`🕊️ ${citizen.name} poistui legendaksi iässä ${Math.floor(citizen.age)}.`);
+      }
+    }
+
+    this.handleInteractions(dt);
+    this.handlePopulationGrowth();
+    this.citizens = this.citizens.filter((citizen) => citizen.alive);
+
+    if (this.citizens.length < 6) {
+      const newcomer = this.createCitizen(this.random() * this.canvas.width, this.random() * this.canvas.height);
+      this.citizens.push(newcomer);
+      this.log(`✨ ${newcomer.name} muutti NeoKylään vahvistamaan tulevaisuutta!`, 'system');
+    }
+
+    this.state.innovationPoints = clamp(this.state.innovationPoints, 0, 9999);
+
+    if (this.tick % this.uiUpdateStride === 0) {
+      this.updatePanels();
+    }
+  }
+
+  private handleInteractions(dt: number): void {
+    for (let i = 0; i < this.citizens.length; i++) {
+      for (let j = i + 1; j < this.citizens.length; j++) {
+        const a = this.citizens[i];
+        const b = this.citizens[j];
+        const d2 = squaredDistance(a.x, a.y, b.x, b.y);
+
+        if (d2 < 24 * 24) {
+          a.needs.social += dt * 11.5;
+          b.needs.social += dt * 11.5;
+          a.needs.health += dt * 2;
+          b.needs.health += dt * 2;
+
+          if (!a.connections.includes(b.id) && this.random() < 0.007) {
+            a.connections.push(b.id);
+            b.connections.push(a.id);
+            this.state.innovationPoints += 4;
+            this.log(`🤝 ${a.name} ja ${b.name} loivat uuden idealiiton.`);
+          }
+
+          if (this.random() < 0.0035) {
+            a.creativity += 1.5;
+            b.creativity += 1.5;
+            this.state.innovationPoints += 1;
+          }
+        }
+      }
+    }
+  }
+
+  private handlePopulationGrowth(): void {
+    if (this.tick % 500 !== 0 || this.citizens.length > 28) return;
+
+    const thriving = this.citizens.filter((c) => c.mood > 68 && c.needs.health > 58);
+    if (thriving.length >= 3) {
+      const child = this.createCitizen(
+        this.canvas.width * (0.25 + this.random() * 0.5),
+        this.canvas.height * (0.25 + this.random() * 0.5)
+      );
+      child.age = 1;
+      child.creativity = 82;
+      this.citizens.push(child);
+      this.state.innovationPoints += 8;
+      this.updatePanels();
+      this.log(`👶 Uusi sukupolvi: ${child.name} syntyi täynnä potentiaalia!`, 'system');
+    }
+  }
+
+  private findNearestCitizen(citizen: Citizen): Citizen | undefined {
+    let closest: Citizen | undefined;
+    let dist = Number.POSITIVE_INFINITY;
+
+    for (const other of this.citizens) {
+      if (other.id === citizen.id || !other.alive) continue;
+      const d2 = squaredDistance(citizen.x, citizen.y, other.x, other.y);
+      if (d2 < dist) {
+        dist = d2;
+        closest = other;
+      }
+    }
+
+    return closest;
+  }
+
+  private render(): void {
+    this.ctx.fillStyle = '#05070f';
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    this.backgroundDrift += 0.003;
+    this.drawGrid();
+
+    for (const citizen of this.citizens) {
+      const moodColor = citizen.mood > 70 ? '#7CFFB2' : citizen.mood > 45 ? '#FFD166' : '#FF6B6B';
+
+      const pulse = 8 + Math.sin(this.tick * 0.06 + citizen.id) * 1.2;
+      this.ctx.beginPath();
+      this.ctx.fillStyle = moodColor;
+      this.ctx.arc(citizen.x, citizen.y, pulse, 0, Math.PI * 2);
+      this.ctx.fill();
+
+      if (this.state.visualFx) {
+        this.ctx.beginPath();
+        this.ctx.strokeStyle = `${moodColor}66`;
+        this.ctx.lineWidth = 2;
+        this.ctx.arc(citizen.x, citizen.y, pulse + 4, 0, Math.PI * 2);
+        this.ctx.stroke();
+      }
+
+      this.ctx.fillStyle = '#d8e0ff';
+      this.ctx.font = '10px monospace';
+      this.ctx.fillText(citizen.name, citizen.x - 22, citizen.y - 12);
+    }
+
+    if (this.state.paused) {
+      this.ctx.fillStyle = 'rgba(4, 8, 20, 0.55)';
+      this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+      this.ctx.fillStyle = '#ffffff';
+      this.ctx.font = 'bold 30px monospace';
+      this.ctx.fillText('PAUSE', this.canvas.width / 2 - 60, this.canvas.height / 2);
+    }
+
+    if (this.state.debugOverlay) {
+      this.drawDebugOverlay();
+    }
+  }
+
+  private updateFps(dt: number): void {
+    this.frameCounter += 1;
+    this.frameTimer += dt;
+
+    if (this.frameTimer >= 0.5) {
+      this.fps = Math.round(this.frameCounter / this.frameTimer);
+      this.frameCounter = 0;
+      this.frameTimer = 0;
+    }
+  }
+
+  private drawDebugOverlay(): void {
+    const avgMood = this.average((c) => c.mood);
+    const delta = this.citizens.length - this.previousPopulation;
+    const trend = delta > 0 ? `+${delta}` : `${delta}`;
+
+    this.ctx.fillStyle = 'rgba(8, 14, 36, 0.7)';
+    this.ctx.fillRect(8, 8, 240, 70);
+    this.ctx.fillStyle = '#9cf6ff';
+    this.ctx.font = '12px monospace';
+    this.ctx.fillText(`FPS: ${this.fps}`, 16, 26);
+    this.ctx.fillText(`Population: ${this.citizens.length} (${trend})`, 16, 44);
+    this.ctx.fillText(`Avg mood: ${avgMood.toFixed(1)}`, 16, 62);
+  }
+
+  private drawGrid(): void {
+    const glow = 0.18 + Math.abs(Math.sin(this.backgroundDrift)) * 0.12;
+    this.ctx.strokeStyle = `rgba(56, 74, 120, ${glow})`;
+    this.ctx.lineWidth = 1;
+
+    for (let x = 0; x <= this.canvas.width; x += 40) {
+      this.ctx.beginPath();
+      this.ctx.moveTo(x, 0);
+      this.ctx.lineTo(x, this.canvas.height);
+      this.ctx.stroke();
+    }
+
+    for (let y = 0; y <= this.canvas.height; y += 40) {
+      this.ctx.beginPath();
+      this.ctx.moveTo(0, y);
+      this.ctx.lineTo(this.canvas.width, y);
+      this.ctx.stroke();
+    }
+  }
+
+  private updatePanels(): void {
+    const population = this.citizens.length;
+    const avgMood = this.average((c) => c.mood);
+    const avgCreativity = this.average((c) => c.creativity);
+    const socialLinks = this.citizens.reduce((sum, c) => sum + c.connections.length, 0) / 2;
+
+    this.statsPanel.innerHTML = `
+      <div class="stat-row"><span>Asukkaat:</span><span>${population}</span></div>
+      <div class="stat-row"><span>Keskim. mieliala:</span><span>${avgMood.toFixed(1)}</span></div>
+      <div class="stat-row"><span>Keskim. luovuus:</span><span>${avgCreativity.toFixed(1)}</span></div>
+      <div class="stat-row"><span>Ystävyyssuhteet:</span><span>${Math.floor(socialLinks)}</span></div>
+      <div class="stat-row"><span>Innovaatiopisteet:</span><span>${this.state.innovationPoints}</span></div>
+    `;
+
+    const needs = ['energy', 'social', 'curiosity', 'health'] as NeedName[];
+    this.needsPanel.innerHTML = needs
+      .map((need) => {
+        const value = this.average((c) => c.needs[need]);
+        const klass = value < 30 ? 'critical' : value < 60 ? 'low' : '';
+        return `
+          <div class="stat-row"><span>${this.translateNeed(need)}:</span><span>${value.toFixed(0)}%</span></div>
+          <div class="need-bar"><div class="need-fill ${klass}" style="width:${value}%"></div></div>
+        `;
+      })
+      .join('');
+
+    this.statusPanel.innerHTML = `
+      <div class="stat-row"><span>Simuloitu vuosi:</span><span>${this.year}</span></div>
+      <div class="stat-row"><span>Syklin numero:</span><span>${this.tick}</span></div>
+      <div class="stat-row"><span>Kausi:</span><span>${this.state.season}</span></div>
+      <div class="stat-row"><span>Tila-moodi:</span><span>${this.state.mode}</span></div>
+      <div class="stat-row"><span>Utopia-indeksi:</span><span>${((avgMood + avgCreativity) / 2).toFixed(1)}</span></div>
+      <div class="stat-row"><span>Tila:</span><span>${avgMood > 70 ? 'Kukoistava' : avgMood > 50 ? 'Vakaa' : 'Haastava'}</span></div>
+    `;
+  }
+
+  private translateNeed(need: NeedName): string {
+    return { energy: 'Energia', social: 'Yhteisöllisyys', curiosity: 'Uteliaisuus', health: 'Terveys' }[need];
+  }
+
+  private average(selector: (citizen: Citizen) => number): number {
+    if (this.citizens.length === 0) return 0;
+    return this.citizens.reduce((sum, citizen) => sum + selector(citizen), 0) / this.citizens.length;
+  }
+
+  private bootstrapRandomSource(): void {
+    const params = new URLSearchParams(window.location.search);
+    const seed = params.get('seed');
+
+    if (!seed) return;
+
+    const parsed = Number(seed);
+    if (!Number.isFinite(parsed)) return;
+
+    this.activeSeed = parsed >>> 0;
+    this.random = createSeededRandom(this.activeSeed);
+    this.log(`🧬 Deterministinen seed käytössä: ${this.activeSeed}`, 'system');
+  }
+
+  private log(message: string, type: 'system' | 'combat' | 'drug' = 'system'): void {
+    const line = document.createElement('div');
+    line.className = `message ${type}`;
+    line.textContent = `[${this.year}] ${message}`;
+    this.messageLog.prepend(line);
+
+    while (this.messageLog.childElementCount > 18) {
+      this.messageLog.removeChild(this.messageLog.lastElementChild!);
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,12 @@
-import { IntegratedGame } from './game-integrated.ts';
+import { GeniusLifeApp } from './genius-life-app.ts';
 
-// Initialize the integrated game when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
-  console.log('🎮 Initializing UHO: Fate of the Grid with integrated systems...');
-  
-  const game = new IntegratedGame();
-  game.start();
-  
-  // Expose game instance for debugging
-  (window as any).game = game;
-  (window as any).integratedGame = game;
-  
-  // Add helpful console commands for the integrated game
-  (window as any).getCurrentScene = () => game.getCurrentScene()?.name;
-  (window as any).getCamera = () => game.getGameplayCamera();
-  (window as any).inputManager = (window as any).inputManager; // Already exposed by IntegratedGame
-  (window as any).sceneManager = (window as any).sceneManager; // Already exposed by IntegratedGame
-  
-  console.log('✅ Game initialized successfully!');
-  console.log('🎯 New Features Available:');
-  console.log('1. 🎮 Connect an Xbox controller for gamepad support with haptic feedback');
-  console.log('2. 🖱️ Use keyboard/mouse or gamepad to navigate menus');
-  console.log('3. 👤 Try the character creation system with 6 unique backgrounds');
-  console.log('4. ⚙️ Configure settings including complete control remapping');
-  console.log('5. 🎭 Experience seamless transitions between all scenes');
-  console.log('');
-  console.log('🔧 Console commands:');
-  console.log('- getCurrentScene() - Get current scene ID');
-  console.log('- getCamera() - Get gameplay camera (when in game)');
-  console.log('- inputManager - Access input system');
-  console.log('- sceneManager - Access scene management');
-  console.log('');
-  console.log('🎲 Have fun playing!');
+  const app = new GeniusLifeApp();
+  app.start();
+
+  window.addEventListener('beforeunload', () => app.stop());
+
+  (window as any).lifeApp = app;
+  console.log('🧠 Genius Life App käynnissä. NeoKylä simuloi elämää ikkunassa.');
+  console.log('⌨️ Pikanäppäimet: Space = pause, F = speed, D = overlay, R = reset.');
 });

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clamp,
+  computeMood,
+  createSeededRandom,
+  inferModeForIntensity,
+  squaredDistance,
+  type NeedsState
+} from '../src/genius-life-app.ts';
+
+describe('genius-life-app helpers', () => {
+  it('clamp keeps values in bounds', () => {
+    expect(clamp(12, 0, 10)).toBe(10);
+    expect(clamp(-4, 0, 10)).toBe(0);
+    expect(clamp(7, 0, 10)).toBe(7);
+  });
+
+  it('squaredDistance avoids sqrt and returns stable values', () => {
+    expect(squaredDistance(0, 0, 3, 4)).toBe(25);
+    expect(squaredDistance(10, 5, 10, 5)).toBe(0);
+  });
+
+  it('computeMood applies profession bonus and clamps max', () => {
+    const goodNeeds: NeedsState = { energy: 95, social: 90, curiosity: 96, health: 94 };
+    expect(computeMood(goodNeeds, 'Taiteilija')).toBe(95.75);
+
+    const peakNeeds: NeedsState = { energy: 100, social: 100, curiosity: 100, health: 100 };
+    expect(computeMood(peakNeeds, 'Taiteilija')).toBe(100);
+  });
+
+  it('createSeededRandom produces deterministic sequence', () => {
+    const a = createSeededRandom(12345);
+    const b = createSeededRandom(12345);
+
+    const seqA = [a(), a(), a()];
+    const seqB = [b(), b(), b()];
+
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('inferModeForIntensity maps values to modes', () => {
+    expect(inferModeForIntensity(0.6)).toBe('Calm');
+    expect(inferModeForIntensity(1.0)).toBe('Balanced');
+    expect(inferModeForIntensity(1.8)).toBe('Chaos');
+  });
+});


### PR DESCRIPTION
### Motivation

- Replace the previous integrated game entry with a new lightweight life simulator (NeoKylä) to prototype a social/creative simulation experience. 
- Provide in-browser controls, debug overlay and deterministic seeding for repeatable runs and experiments. 
- Add unit tests for small pure helpers to ensure deterministic behavior of core utilities.

### Description

- Add a new simulation implementation in `src/genius-life-app.ts` which implements citizens, needs, interactions, rendering, UI panels and controls (modes, seed, speed, pause, boosts, etc.).
- Replace the old startup flow in `src/main.ts` to instantiate `GeniusLifeApp` and expose the app as `window.lifeApp`, and wire up `beforeunload` to stop the app.
- Update `index.html` UI text and layout (title, panel headings) and add a `controlsPanel` area and related styling for the new simulator UI.
- Update `package.json` with new convenience scripts (`dev:sim`, `typecheck:sim`, `build:sim`, `test:fast`) and add `jsdom` as a devDependency; update `package-lock.json` accordingly to include the new dependency tree.
- Add unit tests in `tests/genius-life-app.spec.ts` that cover `clamp`, `squaredDistance`, `computeMood`, `createSeededRandom` and `inferModeForIntensity` helpers.

### Testing

- Ran unit tests with `npm test` (Vitest); all 5 unit test cases in `tests/genius-life-app.spec.ts` passed.
- Started the simulator locally using `npm run dev:sim` to verify the app boots, attaches to DOM elements and responds to controls (manual smoke test succeeded).
- Performed a TypeScript typecheck for the simulator entry points using `npm run typecheck:sim` (typecheck completed without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8d52209188320bbf16347e6229a9e)