### PR TITLE
Decouple simulation ticks from render frames to restore deterministic timing

### DIFF
--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -87,6 +87,27 @@ const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
 const SIM_TICK_SECONDS = 1 / 60;
 const MAX_SIM_STEPS_PER_FRAME = 8;
 
+export interface SimulationStepPlan {
+  steps: number;
+  remainingAccumulator: number;
+}
+
+export function planSimulationSteps(
+  accumulator: number,
+  tickSeconds: number,
+  maxSteps: number
+): SimulationStepPlan {
+  let steps = 0;
+  let remainingAccumulator = accumulator;
+
+  while (remainingAccumulator >= tickSeconds && steps < maxSteps) {
+    remainingAccumulator -= tickSeconds;
+    steps += 1;
+  }
+
+  return { steps, remainingAccumulator };
+}
+
 export class GeniusLifeApp {
   private canvas: HTMLCanvasElement;
   private ctx: CanvasRenderingContext2D;
@@ -484,15 +505,19 @@ export class GeniusLifeApp {
 
     if (!this.state.paused) {
       this.simulationAccumulator += dt * this.state.speed;
-      let simulatedSteps = 0;
-      while (this.simulationAccumulator >= SIM_TICK_SECONDS && simulatedSteps < MAX_SIM_STEPS_PER_FRAME) {
+      const { steps, remainingAccumulator } = planSimulationSteps(
+        this.simulationAccumulator,
+        SIM_TICK_SECONDS,
+        MAX_SIM_STEPS_PER_FRAME
+      );
+
+      for (let i = 0; i < steps; i += 1) {
         this.update(SIM_TICK_SECONDS);
-        this.simulationAccumulator -= SIM_TICK_SECONDS;
-        simulatedSteps += 1;
       }
 
       // Preserve any unprocessed simulation time so long/slow frames catch up deterministically
       // across subsequent render frames instead of dropping elapsed simulation progress.
+      this.simulationAccumulator = remainingAccumulator;
     }
     this.render();
     this.raf = requestAnimationFrame(this.loop);

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -99,6 +99,11 @@ function normalizeAccumulator(accumulator: number): number {
   return Math.max(0, accumulator);
 }
 
+function normalizeTickSeconds(tickSeconds: number): number {
+  if (!Number.isFinite(tickSeconds)) return 0;
+  return tickSeconds;
+}
+
 function normalizeMaxSteps(maxSteps: number): number {
   if (maxSteps === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(maxSteps)) return 0;
@@ -111,7 +116,7 @@ export function planSimulationSteps(
   maxSteps: number
 ): SimulationStepPlan {
   const safeAccumulator = normalizeAccumulator(accumulator);
-  const safeTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
+  const safeTickSeconds = normalizeTickSeconds(tickSeconds);
   const safeMaxSteps = normalizeMaxSteps(maxSteps);
 
   if (safeTickSeconds <= 0 || safeMaxSteps <= 0) {

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -99,15 +99,16 @@ export function planSimulationSteps(
   maxSteps: number
 ): SimulationStepPlan {
   const safeAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
+  const safeTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
   const safeMaxSteps = Number.isFinite(maxSteps) ? Math.floor(maxSteps) : 0;
 
-  if (tickSeconds <= 0 || safeMaxSteps <= 0) {
+  if (safeTickSeconds <= 0 || safeMaxSteps <= 0) {
     return { steps: 0, remainingAccumulator: safeAccumulator };
   }
 
-  const possibleSteps = Math.floor(safeAccumulator / tickSeconds);
+  const possibleSteps = Math.floor(safeAccumulator / safeTickSeconds);
   const steps = Math.min(possibleSteps, safeMaxSteps);
-  const remainingAccumulator = safeAccumulator - steps * tickSeconds;
+  const remainingAccumulator = safeAccumulator - steps * safeTickSeconds;
 
   return {
     steps,

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -94,6 +94,11 @@ interface SimulationStepPlan {
 }
 
 
+function normalizeAccumulator(accumulator: number): number {
+  if (!Number.isFinite(accumulator)) return 0;
+  return Math.max(0, accumulator);
+}
+
 function normalizeMaxSteps(maxSteps: number): number {
   if (maxSteps === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(maxSteps)) return 0;
@@ -105,7 +110,7 @@ export function planSimulationSteps(
   tickSeconds: number,
   maxSteps: number
 ): SimulationStepPlan {
-  const safeAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
+  const safeAccumulator = normalizeAccumulator(accumulator);
   const safeTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
   const safeMaxSteps = normalizeMaxSteps(maxSteps);
 

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -93,6 +93,14 @@ interface SimulationStepPlan {
   remainingAccumulator: number;
 }
 
+
+function normalizeMaxSteps(maxSteps: number): number {
+  if (Number.isNaN(maxSteps)) return 0;
+  if (maxSteps === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(maxSteps)) return 0;
+  return Math.max(0, Math.floor(maxSteps));
+}
+
 export function planSimulationSteps(
   accumulator: number,
   tickSeconds: number,
@@ -100,7 +108,7 @@ export function planSimulationSteps(
 ): SimulationStepPlan {
   const safeAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
   const safeTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
-  const safeMaxSteps = Number.isNaN(maxSteps) ? 0 : Math.max(0, Math.floor(maxSteps));
+  const safeMaxSteps = normalizeMaxSteps(maxSteps);
 
   if (safeTickSeconds <= 0 || safeMaxSteps <= 0) {
     return { steps: 0, remainingAccumulator: safeAccumulator };

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -100,7 +100,7 @@ export function planSimulationSteps(
 ): SimulationStepPlan {
   const safeAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
   const safeTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
-  const safeMaxSteps = Number.isFinite(maxSteps) ? Math.floor(maxSteps) : 0;
+  const safeMaxSteps = Number.isNaN(maxSteps) ? 0 : Math.max(0, Math.floor(maxSteps));
 
   if (safeTickSeconds <= 0 || safeMaxSteps <= 0) {
     return { steps: 0, remainingAccumulator: safeAccumulator };

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -106,14 +106,12 @@ export function planSimulationSteps(
     return { steps: 0, remainingAccumulator: safeAccumulator };
   }
 
-  const possibleSteps = Math.floor(safeAccumulator / safeTickSeconds);
+  const possibleSteps = Math.max(0, Math.floor(safeAccumulator / safeTickSeconds));
   const steps = Math.min(possibleSteps, safeMaxSteps);
-  const remainingAccumulator = safeAccumulator - steps * safeTickSeconds;
+  const rawRemainingAccumulator = safeAccumulator - steps * safeTickSeconds;
+  const remainingAccumulator = rawRemainingAccumulator <= SIM_ACCUMULATOR_EPSILON ? 0 : rawRemainingAccumulator;
 
-  return {
-    steps,
-    remainingAccumulator: remainingAccumulator < SIM_ACCUMULATOR_EPSILON ? 0 : remainingAccumulator
-  };
+  return { steps, remainingAccumulator };
 }
 
 export class GeniusLifeApp {

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -128,7 +128,7 @@ export function planSimulationSteps(
     return { steps: 0, remainingAccumulator: safeAccumulator, capped: false };
   }
 
-  const possibleSteps = Math.max(0, Math.floor(safeAccumulator / safeTickSeconds));
+  const possibleSteps = Math.max(0, Math.floor((safeAccumulator + SIM_ACCUMULATOR_EPSILON) / safeTickSeconds));
   const steps = Math.min(possibleSteps, safeMaxSteps);
   const capped = possibleSteps > safeMaxSteps;
   const rawRemainingAccumulator = safeAccumulator - steps * safeTickSeconds;

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -97,19 +97,22 @@ export function planSimulationSteps(
   tickSeconds: number,
   maxSteps: number
 ): SimulationStepPlan {
-  if (tickSeconds <= 0 || maxSteps <= 0) {
-    return { steps: 0, remainingAccumulator: accumulator };
+  const normalizedAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
+  const normalizedTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
+  const normalizedMaxSteps = Number.isFinite(maxSteps) ? Math.floor(maxSteps) : 0;
+
+  if (normalizedTickSeconds <= 0 || normalizedMaxSteps <= 0) {
+    return { steps: 0, remainingAccumulator: normalizedAccumulator };
   }
 
-  let steps = 0;
-  let remainingAccumulator = accumulator;
+  const possibleSteps = Math.floor(normalizedAccumulator / normalizedTickSeconds);
+  const steps = Math.min(possibleSteps, normalizedMaxSteps);
+  const remainingAccumulator = normalizedAccumulator - steps * normalizedTickSeconds;
 
-  while (remainingAccumulator >= tickSeconds && steps < maxSteps) {
-    remainingAccumulator -= tickSeconds;
-    steps += 1;
-  }
-
-  return { steps, remainingAccumulator };
+  return {
+    steps,
+    remainingAccumulator: remainingAccumulator < 1e-9 ? 0 : remainingAccumulator
+  };
 }
 
 export class GeniusLifeApp {

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -97,6 +97,10 @@ export function planSimulationSteps(
   tickSeconds: number,
   maxSteps: number
 ): SimulationStepPlan {
+  if (tickSeconds <= 0 || maxSteps <= 0) {
+    return { steps: 0, remainingAccumulator: accumulator };
+  }
+
   let steps = 0;
   let remainingAccumulator = accumulator;
 

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -98,17 +98,16 @@ export function planSimulationSteps(
   tickSeconds: number,
   maxSteps: number
 ): SimulationStepPlan {
-  const normalizedAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
-  const normalizedTickSeconds = Number.isFinite(tickSeconds) ? tickSeconds : 0;
-  const normalizedMaxSteps = Number.isFinite(maxSteps) ? Math.floor(maxSteps) : 0;
+  const safeAccumulator = Number.isFinite(accumulator) ? Math.max(0, accumulator) : 0;
+  const safeMaxSteps = Number.isFinite(maxSteps) ? Math.floor(maxSteps) : 0;
 
-  if (normalizedTickSeconds <= 0 || normalizedMaxSteps <= 0) {
-    return { steps: 0, remainingAccumulator: normalizedAccumulator };
+  if (tickSeconds <= 0 || safeMaxSteps <= 0) {
+    return { steps: 0, remainingAccumulator: safeAccumulator };
   }
 
-  const possibleSteps = Math.floor(normalizedAccumulator / normalizedTickSeconds);
-  const steps = Math.min(possibleSteps, normalizedMaxSteps);
-  const remainingAccumulator = normalizedAccumulator - steps * normalizedTickSeconds;
+  const possibleSteps = Math.floor(safeAccumulator / tickSeconds);
+  const steps = Math.min(possibleSteps, safeMaxSteps);
+  const remainingAccumulator = safeAccumulator - steps * tickSeconds;
 
   return {
     steps,

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -86,6 +86,7 @@ const PROFESSIONS: Profession[] = ['Keksijä', 'Taiteilija', 'Opettaja', 'Rakent
 const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
 const SIM_TICK_SECONDS = 1 / 60;
 const MAX_SIM_STEPS_PER_FRAME = 8;
+const SIM_ACCUMULATOR_EPSILON = 1e-9;
 
 export interface SimulationStepPlan {
   steps: number;
@@ -111,7 +112,7 @@ export function planSimulationSteps(
 
   return {
     steps,
-    remainingAccumulator: remainingAccumulator < 1e-9 ? 0 : remainingAccumulator
+    remainingAccumulator: remainingAccumulator < SIM_ACCUMULATOR_EPSILON ? 0 : remainingAccumulator
   };
 }
 

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -491,9 +491,8 @@ export class GeniusLifeApp {
         simulatedSteps += 1;
       }
 
-      if (simulatedSteps === MAX_SIM_STEPS_PER_FRAME) {
-        this.simulationAccumulator = 0;
-      }
+      // Preserve any unprocessed simulation time so long/slow frames catch up deterministically
+      // across subsequent render frames instead of dropping elapsed simulation progress.
     }
     this.render();
     this.raf = requestAnimationFrame(this.loop);

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -84,6 +84,8 @@ export function seasonPaceModifier(season: GlobalState['season']): number {
 const NAMES = ['Aino', 'Eero', 'Veera', 'Sisu', 'Lumi', 'Milo', 'Nora', 'Onni', 'Helmi', 'Otso'];
 const PROFESSIONS: Profession[] = ['Keksijä', 'Taiteilija', 'Opettaja', 'Rakentaja'];
 const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
+const SIM_TICK_SECONDS = 1 / 60;
+const MAX_SIM_STEPS_PER_FRAME = 8;
 
 export class GeniusLifeApp {
   private canvas: HTMLCanvasElement;
@@ -94,6 +96,7 @@ export class GeniusLifeApp {
   private tick = 0;
   private raf = 0;
   private lastTime = 0;
+  private simulationAccumulator = 0;
 
   private messageLog: HTMLElement;
   private statsPanel: HTMLElement;
@@ -174,6 +177,7 @@ export class GeniusLifeApp {
     if (this.running) return;
     this.running = true;
     this.lastTime = performance.now();
+    this.simulationAccumulator = 0;
     this.loop(this.lastTime);
   }
 
@@ -474,12 +478,22 @@ export class GeniusLifeApp {
 
   private loop = (now: number): void => {
     if (!this.running) return;
-    const dt = Math.min((now - this.lastTime) / 1000, 0.05);
+    const dt = Math.min((now - this.lastTime) / 1000, 0.25);
     this.lastTime = now;
     this.updateFps(dt);
 
     if (!this.state.paused) {
-      this.update(dt * this.state.speed);
+      this.simulationAccumulator += dt * this.state.speed;
+      let simulatedSteps = 0;
+      while (this.simulationAccumulator >= SIM_TICK_SECONDS && simulatedSteps < MAX_SIM_STEPS_PER_FRAME) {
+        this.update(SIM_TICK_SECONDS);
+        this.simulationAccumulator -= SIM_TICK_SECONDS;
+        simulatedSteps += 1;
+      }
+
+      if (simulatedSteps === MAX_SIM_STEPS_PER_FRAME) {
+        this.simulationAccumulator = 0;
+      }
     }
     this.render();
     this.raf = requestAnimationFrame(this.loop);

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -128,7 +128,17 @@ export function planSimulationSteps(
     return { steps: 0, remainingAccumulator: safeAccumulator, capped: false };
   }
 
-  const possibleSteps = Math.max(0, Math.floor((safeAccumulator + SIM_ACCUMULATOR_EPSILON) / safeTickSeconds));
+  const quotient = safeAccumulator / safeTickSeconds;
+  let possibleSteps = Math.max(0, Math.floor(quotient));
+  let normalizedRemainder = safeAccumulator - possibleSteps * safeTickSeconds;
+
+  // Compensate for floating-point precision (e.g. 0.3 / 0.1) without creating time from
+  // materially sub-tick accumulators.
+  if (normalizedRemainder + SIM_ACCUMULATOR_EPSILON >= safeTickSeconds) {
+    possibleSteps += 1;
+    normalizedRemainder -= safeTickSeconds;
+  }
+
   const steps = Math.min(possibleSteps, safeMaxSteps);
   const capped = possibleSteps > safeMaxSteps;
   const rawRemainingAccumulator = safeAccumulator - steps * safeTickSeconds;

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -95,7 +95,6 @@ interface SimulationStepPlan {
 
 
 function normalizeMaxSteps(maxSteps: number): number {
-  if (Number.isNaN(maxSteps)) return 0;
   if (maxSteps === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(maxSteps)) return 0;
   return Math.max(0, Math.floor(maxSteps));

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -91,6 +91,7 @@ const SIM_ACCUMULATOR_EPSILON = 1e-9;
 interface SimulationStepPlan {
   steps: number;
   remainingAccumulator: number;
+  capped: boolean;
 }
 
 
@@ -124,15 +125,16 @@ export function planSimulationSteps(
   const safeMaxSteps = normalizeMaxSteps(maxSteps);
 
   if (safeTickSeconds <= 0 || safeMaxSteps <= 0) {
-    return { steps: 0, remainingAccumulator: safeAccumulator };
+    return { steps: 0, remainingAccumulator: safeAccumulator, capped: false };
   }
 
   const possibleSteps = Math.max(0, Math.floor(safeAccumulator / safeTickSeconds));
   const steps = Math.min(possibleSteps, safeMaxSteps);
+  const capped = possibleSteps > safeMaxSteps;
   const rawRemainingAccumulator = safeAccumulator - steps * safeTickSeconds;
   const remainingAccumulator = rawRemainingAccumulator <= SIM_ACCUMULATOR_EPSILON ? 0 : rawRemainingAccumulator;
 
-  return { steps, remainingAccumulator };
+  return { steps, remainingAccumulator, capped };
 }
 
 export class GeniusLifeApp {

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -88,7 +88,7 @@ const SIM_TICK_SECONDS = 1 / 60;
 const MAX_SIM_STEPS_PER_FRAME = 8;
 const SIM_ACCUMULATOR_EPSILON = 1e-9;
 
-export interface SimulationStepPlan {
+interface SimulationStepPlan {
   steps: number;
   remainingAccumulator: number;
 }

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -94,9 +94,13 @@ interface SimulationStepPlan {
 }
 
 
+function normalizeNonNegativeFinite(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
 function normalizeAccumulator(accumulator: number): number {
-  if (!Number.isFinite(accumulator)) return 0;
-  return Math.max(0, accumulator);
+  return normalizeNonNegativeFinite(accumulator);
 }
 
 function normalizeTickSeconds(tickSeconds: number): number {
@@ -107,7 +111,7 @@ function normalizeTickSeconds(tickSeconds: number): number {
 function normalizeMaxSteps(maxSteps: number): number {
   if (maxSteps === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(maxSteps)) return 0;
-  return Math.max(0, Math.floor(maxSteps));
+  return Math.floor(normalizeNonNegativeFinite(maxSteps));
 }
 
 export function planSimulationSteps(

--- a/src/top-down-village.ts
+++ b/src/top-down-village.ts
@@ -222,7 +222,7 @@ export class TopDownVillageGenerator {
       dialogue: [
         'Welcome to my shop! Best prices in town!',
         'Fresh goods arrive every week from the capital.',
-        'Is there anything specific you\\'re looking for?'
+        'Is there anything specific you\'re looking for?'
       ],
       quests: [
         {
@@ -241,7 +241,7 @@ export class TopDownVillageGenerator {
       role: 'guard',
       dialogue: [
         'Stay alert, citizen. Dangerous times ahead.',
-        'I\\'ve been guarding this village for 15 years.',
+        'I\'ve been guarding this village for 15 years.',
         'Report any suspicious activity to me immediately.'
       ],
       patrol: [

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -107,6 +107,14 @@ describe('genius-life-app helpers', () => {
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.5, 10);
   });
 
+  it('planSimulationSteps rejects negative infinite maxSteps', () => {
+    const tickSeconds = 1 / 60;
+    const plan = planSimulationSteps(tickSeconds * 3.5, tickSeconds, Number.NEGATIVE_INFINITY);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 3.5, 10);
+  });
+
 
   it('planSimulationSteps avoids stepping when tickSeconds is invalid', () => {
     const accumulator = 1;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -114,6 +114,17 @@ describe('genius-life-app helpers', () => {
     expect(plan.capped).toBe(false);
   });
 
+  it('planSimulationSteps does not overcount materially sub-tick accumulator values', () => {
+    const tickSeconds = 0.1;
+    const accumulator = tickSeconds - 1e-6;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, 3);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 12);
+    expect(plan.capped).toBe(false);
+  });
+
 
   it('planSimulationSteps clamps near-zero floating remainder to zero', () => {
     const tickSeconds = 0.1;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -106,6 +106,15 @@ describe('genius-life-app helpers', () => {
     expect(plan.steps).toBe(3);
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.5, 10);
   });
+  it('planSimulationSteps treats NaN maxSteps as zero', () => {
+    const tickSeconds = 1 / 60;
+    const accumulator = tickSeconds * 2;
+    const plan = planSimulationSteps(accumulator, tickSeconds, Number.NaN);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+  });
+
 
   it('planSimulationSteps rejects negative infinite maxSteps', () => {
     const tickSeconds = 1 / 60;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -53,6 +53,7 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(8);
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 2.5, 10);
+    expect(plan.capped).toBe(true);
   });
 
   it('planSimulationSteps consumes all available steps below the cap', () => {
@@ -61,6 +62,7 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(3);
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.25, 10);
+    expect(plan.capped).toBe(false);
   });
 
   it('planSimulationSteps avoids stepping when maxSteps is zero', () => {
@@ -71,6 +73,7 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+    expect(plan.capped).toBe(false);
   });
 
   it('planSimulationSteps floors non-integer maxSteps to avoid extra ticks', () => {
@@ -81,21 +84,24 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+    expect(plan.capped).toBe(false);
   });
+
   it('planSimulationSteps treats infinite accumulator as zero', () => {
     const tickSeconds = 1 / 60;
     const plan = planSimulationSteps(Number.POSITIVE_INFINITY, tickSeconds, 8);
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBe(0);
+    expect(plan.capped).toBe(false);
   });
 
 
   it('planSimulationSteps normalizes invalid accumulator inputs', () => {
     const tickSeconds = 1 / 60;
 
-    expect(planSimulationSteps(-1, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0 });
-    expect(planSimulationSteps(Number.NaN, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0 });
+    expect(planSimulationSteps(-1, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0, capped: false });
+    expect(planSimulationSteps(Number.NaN, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0, capped: false });
   });
 
   it('planSimulationSteps clamps near-zero floating remainder to zero', () => {
@@ -106,13 +112,16 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(3);
     expect(plan.remainingAccumulator).toBe(0);
+    expect(plan.capped).toBe(false);
   });
+
   it('planSimulationSteps treats infinite maxSteps as uncapped for the frame', () => {
     const tickSeconds = 1 / 60;
     const plan = planSimulationSteps(tickSeconds * 3.5, tickSeconds, Number.POSITIVE_INFINITY);
 
     expect(plan.steps).toBe(3);
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.5, 10);
+    expect(plan.capped).toBe(false);
   });
   it('planSimulationSteps treats NaN maxSteps as zero', () => {
     const tickSeconds = 1 / 60;
@@ -121,8 +130,8 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+    expect(plan.capped).toBe(false);
   });
-
 
   it('planSimulationSteps rejects negative infinite maxSteps', () => {
     const tickSeconds = 1 / 60;
@@ -130,6 +139,7 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 3.5, 10);
+    expect(plan.capped).toBe(false);
   });
 
 
@@ -138,33 +148,39 @@ describe('genius-life-app helpers', () => {
 
     expect(planSimulationSteps(accumulator, Number.NaN, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
     expect(planSimulationSteps(accumulator, Number.POSITIVE_INFINITY, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
 
     expect(planSimulationSteps(accumulator, Number.NEGATIVE_INFINITY, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
 
     expect(planSimulationSteps(accumulator, 0, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
 
     expect(planSimulationSteps(accumulator, -0, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
   });
   it('planSimulationSteps avoids stepping when tickSeconds is negative', () => {
     const accumulator = 1;
     expect(planSimulationSteps(accumulator, -0.1, 8)).toEqual({
       steps: 0,
-      remainingAccumulator: accumulator
+      remainingAccumulator: accumulator,
+      capped: false
     });
   });
 
@@ -176,8 +192,8 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+    expect(plan.capped).toBe(false);
   });
-
 
   it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {
     const tickSeconds = 1 / 60;
@@ -185,6 +201,7 @@ describe('genius-life-app helpers', () => {
 
     expect(plan.steps).toBe(7);
     expect(plan.remainingAccumulator).toBeGreaterThanOrEqual(0);
+    expect(plan.capped).toBe(false);
     expect(plan.remainingAccumulator).toBeLessThan(tickSeconds);
   });
 

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -6,6 +6,7 @@ import {
   inferModeForIntensity,
   seasonPaceModifier,
   squaredDistance,
+  planSimulationSteps,
   type NeedsState
 } from '../src/genius-life-app.ts';
 
@@ -41,6 +42,25 @@ describe('genius-life-app helpers', () => {
       expect(value).toBeGreaterThanOrEqual(0);
       expect(value).toBeLessThan(1);
     });
+  });
+
+  it('planSimulationSteps preserves overflow time when max steps are hit', () => {
+    const tickSeconds = 1 / 60;
+    const maxSteps = 8;
+    const accumulator = tickSeconds * 10.5;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, maxSteps);
+
+    expect(plan.steps).toBe(8);
+    expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 2.5, 10);
+  });
+
+  it('planSimulationSteps consumes all available steps below the cap', () => {
+    const tickSeconds = 1 / 60;
+    const plan = planSimulationSteps(tickSeconds * 3.25, tickSeconds, 8);
+
+    expect(plan.steps).toBe(3);
+    expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.25, 10);
   });
 
 

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -63,6 +63,16 @@ describe('genius-life-app helpers', () => {
     expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.25, 10);
   });
 
+  it('planSimulationSteps avoids stepping when maxSteps is zero', () => {
+    const tickSeconds = 1 / 60;
+    const accumulator = tickSeconds * 5;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, 0);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+  });
+
 
   it('seasonPaceModifier maps seasons to expected pace values', () => {
     expect(seasonPaceModifier('kevät')).toBe(1);

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -149,6 +149,11 @@ describe('genius-life-app helpers', () => {
       steps: 0,
       remainingAccumulator: accumulator
     });
+
+    expect(planSimulationSteps(accumulator, 0, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
   });
 
   it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -90,6 +90,16 @@ describe('genius-life-app helpers', () => {
     expect(planSimulationSteps(Number.NaN, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0 });
   });
 
+  it('planSimulationSteps clamps near-zero floating remainder to zero', () => {
+    const tickSeconds = 0.1;
+    const accumulator = 0.30000000000000004;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, 3);
+
+    expect(plan.steps).toBe(3);
+    expect(plan.remainingAccumulator).toBe(0);
+  });
+
 
   it('seasonPaceModifier maps seasons to expected pace values', () => {
     expect(seasonPaceModifier('kevät')).toBe(1);

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -100,6 +100,19 @@ describe('genius-life-app helpers', () => {
     expect(plan.remainingAccumulator).toBe(0);
   });
 
+  it('planSimulationSteps avoids stepping when tickSeconds is invalid', () => {
+    const accumulator = 1;
+
+    expect(planSimulationSteps(accumulator, Number.NaN, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
+    expect(planSimulationSteps(accumulator, Number.POSITIVE_INFINITY, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
+  });
+
 
   it('seasonPaceModifier maps seasons to expected pace values', () => {
     expect(seasonPaceModifier('kevät')).toBe(1);

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -103,6 +103,17 @@ describe('genius-life-app helpers', () => {
     expect(planSimulationSteps(-1, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0, capped: false });
     expect(planSimulationSteps(Number.NaN, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0, capped: false });
   });
+  it('planSimulationSteps avoids undercount from floating division precision', () => {
+    const tickSeconds = 0.1;
+    const accumulator = 0.3;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, 3);
+
+    expect(plan.steps).toBe(3);
+    expect(plan.remainingAccumulator).toBe(0);
+    expect(plan.capped).toBe(false);
+  });
+
 
   it('planSimulationSteps clamps near-zero floating remainder to zero', () => {
     const tickSeconds = 0.1;
@@ -199,7 +210,7 @@ describe('genius-life-app helpers', () => {
     const tickSeconds = 1 / 60;
     const plan = planSimulationSteps(tickSeconds * 7.9999999999, tickSeconds, 8);
 
-    expect(plan.steps).toBe(7);
+    expect(plan.steps).toBe(8);
     expect(plan.remainingAccumulator).toBeGreaterThanOrEqual(0);
     expect(plan.capped).toBe(false);
     expect(plan.remainingAccumulator).toBeLessThan(tickSeconds);

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -154,6 +154,11 @@ describe('genius-life-app helpers', () => {
       steps: 0,
       remainingAccumulator: accumulator
     });
+
+    expect(planSimulationSteps(accumulator, -0, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
   });
 
   it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -160,6 +160,24 @@ describe('genius-life-app helpers', () => {
       remainingAccumulator: accumulator
     });
   });
+  it('planSimulationSteps avoids stepping when tickSeconds is negative', () => {
+    const accumulator = 1;
+    expect(planSimulationSteps(accumulator, -0.1, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
+  });
+
+  it('planSimulationSteps avoids stepping when maxSteps is negative fractional', () => {
+    const tickSeconds = 1 / 60;
+    const accumulator = tickSeconds * 3;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, -0.5);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+  });
+
 
   it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {
     const tickSeconds = 1 / 60;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -144,6 +144,11 @@ describe('genius-life-app helpers', () => {
       steps: 0,
       remainingAccumulator: accumulator
     });
+
+    expect(planSimulationSteps(accumulator, Number.NEGATIVE_INFINITY, 8)).toEqual({
+      steps: 0,
+      remainingAccumulator: accumulator
+    });
   });
 
   it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -99,6 +99,14 @@ describe('genius-life-app helpers', () => {
     expect(plan.steps).toBe(3);
     expect(plan.remainingAccumulator).toBe(0);
   });
+  it('planSimulationSteps treats infinite maxSteps as uncapped for the frame', () => {
+    const tickSeconds = 1 / 60;
+    const plan = planSimulationSteps(tickSeconds * 3.5, tickSeconds, Number.POSITIVE_INFINITY);
+
+    expect(plan.steps).toBe(3);
+    expect(plan.remainingAccumulator).toBeCloseTo(tickSeconds * 0.5, 10);
+  });
+
 
   it('planSimulationSteps avoids stepping when tickSeconds is invalid', () => {
     const accumulator = 1;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -113,6 +113,15 @@ describe('genius-life-app helpers', () => {
     });
   });
 
+  it('planSimulationSteps keeps remainingAccumulator bounded below tickSeconds when fully consumed', () => {
+    const tickSeconds = 1 / 60;
+    const plan = planSimulationSteps(tickSeconds * 7.9999999999, tickSeconds, 8);
+
+    expect(plan.steps).toBe(7);
+    expect(plan.remainingAccumulator).toBeGreaterThanOrEqual(0);
+    expect(plan.remainingAccumulator).toBeLessThan(tickSeconds);
+  });
+
 
   it('seasonPaceModifier maps seasons to expected pace values', () => {
     expect(seasonPaceModifier('kevät')).toBe(1);

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -82,6 +82,14 @@ describe('genius-life-app helpers', () => {
     expect(plan.steps).toBe(0);
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
   });
+  it('planSimulationSteps treats infinite accumulator as zero', () => {
+    const tickSeconds = 1 / 60;
+    const plan = planSimulationSteps(Number.POSITIVE_INFINITY, tickSeconds, 8);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBe(0);
+  });
+
 
   it('planSimulationSteps normalizes invalid accumulator inputs', () => {
     const tickSeconds = 1 / 60;

--- a/tests/genius-life-app.spec.ts
+++ b/tests/genius-life-app.spec.ts
@@ -73,6 +73,23 @@ describe('genius-life-app helpers', () => {
     expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
   });
 
+  it('planSimulationSteps floors non-integer maxSteps to avoid extra ticks', () => {
+    const tickSeconds = 1 / 60;
+    const accumulator = tickSeconds * 5;
+
+    const plan = planSimulationSteps(accumulator, tickSeconds, 0.5);
+
+    expect(plan.steps).toBe(0);
+    expect(plan.remainingAccumulator).toBeCloseTo(accumulator, 10);
+  });
+
+  it('planSimulationSteps normalizes invalid accumulator inputs', () => {
+    const tickSeconds = 1 / 60;
+
+    expect(planSimulationSteps(-1, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0 });
+    expect(planSimulationSteps(Number.NaN, tickSeconds, 8)).toEqual({ steps: 0, remainingAccumulator: 0 });
+  });
+
 
   it('seasonPaceModifier maps seasons to expected pace values', () => {
     expect(seasonPaceModifier('kevät')).toBe(1);


### PR DESCRIPTION
### Motivation

- The simulation incremented `tick` once per `requestAnimationFrame` which tied all tick-gated logic (season/year shifts, population growth, harmony decay, etc.) to display refresh rate and broke determinism across different FPS clients.
- The change aims to decouple simulated time from rendering so the same seed produces identical timelines regardless of client refresh rate.

### Description

- Added fixed-step simulation constants `SIM_TICK_SECONDS = 1/60` and `MAX_SIM_STEPS_PER_FRAME = 8` to define simulation cadence and a per-frame cap.
- Introduced a `simulationAccumulator` field and reset it on `start()` so elapsed real time is accumulated into simulation time before stepping the world.
- Reworked the main loop to accumulate `dt * state.speed` and advance the simulation in discrete `SIM_TICK_SECONDS` steps while enforcing the `MAX_SIM_STEPS_PER_FRAME` guard to avoid runaway catch-up.
- Increased the frame-clamp window (`dt` clamp) to tolerate larger frame gaps while keeping rendering decoupled from simulation steps. All existing tick-gated logic remains driven by the simulation step count.

### Testing

- Attempted to run the test suite with `npm test -- --run` which failed in this environment with `vitest: Permission denied`.
- Attempted to run Vitest directly with `node ./node_modules/vitest/vitest.mjs --run` which failed due to a missing optional native dependency (`@rollup/rollup-linux-x64-gnu`) in the environment.
- `tests/genius-life-app.spec.ts` exists and contains unit tests for helper functions (`clamp`, `squaredDistance`, `computeMood`, `createSeededRandom`, `inferModeForIntensity`, `seasonPaceModifier`), but automated execution could not be completed here due to the environment dependency/executable issues described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90abf5e5083209c71660064b8eebc)