### PR TITLE
Implement fixed-timestep simulation loop with accumulator and step cap

### DIFF
--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -84,6 +84,10 @@ export function seasonPaceModifier(season: GlobalState['season']): number {
 const NAMES = ['Aino', 'Eero', 'Veera', 'Sisu', 'Lumi', 'Milo', 'Nora', 'Onni', 'Helmi', 'Otso'];
 const PROFESSIONS: Profession[] = ['Keksijä', 'Taiteilija', 'Opettaja', 'Rakentaja'];
 const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
+const SIM_TICK_SECONDS = 1 / 60;
+const MAX_SIM_STEPS_PER_FRAME = 8;
+const MAX_ACCUMULATED_SIM_SECONDS = SIM_TICK_SECONDS * 240;
+const SIM_TIME_EPSILON = 1e-9;
 
 export class GeniusLifeApp {
   private canvas: HTMLCanvasElement;
@@ -94,6 +98,7 @@ export class GeniusLifeApp {
   private tick = 0;
   private raf = 0;
   private lastTime = 0;
+  private simulationAccumulator = 0;
 
   private messageLog: HTMLElement;
   private statsPanel: HTMLElement;
@@ -174,6 +179,7 @@ export class GeniusLifeApp {
     if (this.running) return;
     this.running = true;
     this.lastTime = performance.now();
+    this.simulationAccumulator = 0;
     this.loop(this.lastTime);
   }
 
@@ -474,12 +480,24 @@ export class GeniusLifeApp {
 
   private loop = (now: number): void => {
     if (!this.running) return;
-    const dt = Math.min((now - this.lastTime) / 1000, 0.05);
+    const dt = Math.min((now - this.lastTime) / 1000, 0.25);
     this.lastTime = now;
     this.updateFps(dt);
 
     if (!this.state.paused) {
-      this.update(dt * this.state.speed);
+      this.simulationAccumulator += dt * this.state.speed;
+      this.simulationAccumulator = Math.min(this.simulationAccumulator, MAX_ACCUMULATED_SIM_SECONDS);
+
+      const availableSteps = Math.floor(this.simulationAccumulator / SIM_TICK_SECONDS);
+      const stepsToSimulate = Math.min(availableSteps, MAX_SIM_STEPS_PER_FRAME);
+      for (let i = 0; i < stepsToSimulate; i++) {
+        this.update(SIM_TICK_SECONDS);
+      }
+
+      this.simulationAccumulator -= stepsToSimulate * SIM_TICK_SECONDS;
+      if (this.simulationAccumulator < SIM_TIME_EPSILON) {
+        this.simulationAccumulator = 0;
+      }
     }
     this.render();
     this.raf = requestAnimationFrame(this.loop);

--- a/src/genius-life-app.ts
+++ b/src/genius-life-app.ts
@@ -86,7 +86,7 @@ const PROFESSIONS: Profession[] = ['Keksijä', 'Taiteilija', 'Opettaja', 'Rakent
 const SEASONS: GlobalState['season'][] = ['kevät', 'kesä', 'syksy', 'talvi'];
 const SIM_TICK_SECONDS = 1 / 60;
 const MAX_SIM_STEPS_PER_FRAME = 8;
-const MAX_ACCUMULATED_SIM_SECONDS = SIM_TICK_SECONDS * 240;
+const MAX_ACCUMULATED_SIM_SECONDS = SIM_TICK_SECONDS * 100;
 const SIM_TIME_EPSILON = 1e-9;
 
 export class GeniusLifeApp {


### PR DESCRIPTION
### Motivation
- Prevent simulation speed and instability from varying frame rates and avoid large variable timesteps causing inconsistent updates.
- Cap the amount of simulation work per frame to prevent the spiral-of-death when frames are slow.

### Description
- Introduce fixed-timestep constants: `SIM_TICK_SECONDS`, `MAX_SIM_STEPS_PER_FRAME`, `MAX_ACCUMULATED_SIM_SECONDS`, and `SIM_TIME_EPSILON` to control simulation pacing.
- Add `simulationAccumulator` state and reset it in `start()` to track accumulated simulation time.
- Replace the previous variable-step update (`update(dt * this.state.speed)`) with an accumulator-driven loop that advances the simulation in fixed `SIM_TICK_SECONDS` steps, limited by `MAX_SIM_STEPS_PER_FRAME` and capped by `MAX_ACCUMULATED_SIM_SECONDS`.
- Increase the frame `dt` clamp from `0.05` to `0.25` and zero out tiny leftover accumulator values to avoid numerical drift.

### Testing
- Ran the TypeScript build with `npm run build`, which completed successfully.
- Ran the linter with `npm run lint`, which reported no new issues.
- Ran unit tests with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90abf5e5083209c71660064b8eebc)